### PR TITLE
feat: add custom HTTP headers for Remnawave API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ REMNAWAVE_API_TOKEN=your-api-token-here
 # Optional cookie auth: semicolon-separated key=value pairs
 REMNAWAVE_COOKIES=
 
+# Optional custom HTTP headers sent with every Remnawave API request.
+# Useful when the panel is behind a proxy/Cloudflare/protection that requires
+# an extra header. Semicolon-separated "Name: Value" pairs; value split on first ":".
+# Example: REMNAWAVE_HEADERS=X-Api-Key: secret123; X-Custom-Header: value
+REMNAWAVE_HEADERS=
+
 # Token from @BotFather
 TELEGRAM_BOT_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ docker compose logs -f limiter                # проверка
 | `REMNAWAVE_API_URL` | **обязательный** | Адрес панели Remnawave |
 | `REMNAWAVE_API_TOKEN` | **обязательный** | API-токен (генерируется в панели) |
 | `REMNAWAVE_COOKIES` | — | Доп. авторизация через cookie. Формат: `key=value` через `;` (напр. `cf_clearance=abc; session=xyz`). Для панелей за Cloudflare/WAF |
+| `REMNAWAVE_HEADERS` | — | Доп. HTTP-заголовки для каждого запроса к API. Формат: `Name: Value` через `;` (напр. `X-Api-Key: secret123; X-Custom-Header: value`). Для панелей за прокси/Cloudflare/защитой |
 | `TELEGRAM_BOT_TOKEN` | **обязательный** | Токен бота от @BotFather |
 | `TELEGRAM_CHAT_ID` | **обязательный** | ID чата/канала/группы для алертов |
 | `TELEGRAM_ADMIN_IDS` | **обязательный** | ID админов через запятую (только они нажимают кнопки) |

--- a/README_en.md
+++ b/README_en.md
@@ -81,6 +81,7 @@ All settings via `.env` or environment variables.
 | `REMNAWAVE_API_URL` | **required** | Remnawave panel address |
 | `REMNAWAVE_API_TOKEN` | **required** | API token (generated in the panel) |
 | `REMNAWAVE_COOKIES` | — | Additional cookie auth. Format: `key=value` separated by `;` (e.g. `cf_clearance=abc; session=xyz`). For panels behind Cloudflare/WAF |
+| `REMNAWAVE_HEADERS` | — | Additional HTTP headers sent with every API request. Format: `Name: Value` separated by `;` (e.g. `X-Api-Key: secret123; X-Custom-Header: value`). For panels behind a proxy/Cloudflare/protection |
 | `TELEGRAM_BOT_TOKEN` | **required** | Bot token from @BotFather |
 | `TELEGRAM_CHAT_ID` | **required** | Chat/channel/group ID for alerts |
 | `TELEGRAM_ADMIN_IDS` | **required** | Admin IDs (comma-separated); only they can press buttons |

--- a/cmd/limiter/main.go
+++ b/cmd/limiter/main.go
@@ -132,6 +132,12 @@ func main() {
 		logger.Info("Cookie авторизация включена")
 	}
 
+	if cfg.RemnawaveHeaders != "" {
+		headers := api.ParseHeaders(cfg.RemnawaveHeaders)
+		apiClient.SetHeaders(headers)
+		logger.Infof("Кастомные заголовки включены (%d)", len(headers))
+	}
+
 	bot, err := telegram.NewBot(cfg.TelegramBotToken, cfg.TelegramChatID, cfg.TelegramThreadID, cfg.TelegramAdminIDs, cfg.TelegramProxy, logger)
 	if err != nil {
 		logger.Fatalf("Ошибка Telegram: %v", err)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -26,6 +26,7 @@ type Client struct {
 	httpClient *http.Client
 	logger     *logrus.Logger
 	cookies    []*http.Cookie
+	headers    map[string]string
 }
 
 func NewClient(baseURL, token string) *Client {
@@ -44,6 +45,37 @@ func (c *Client) SetLogger(logger *logrus.Logger) {
 
 func (c *Client) SetCookies(cookies []*http.Cookie) {
 	c.cookies = cookies
+}
+
+func (c *Client) SetHeaders(headers map[string]string) {
+	c.headers = headers
+}
+
+func ParseHeaders(headerStr string) map[string]string {
+	if headerStr == "" {
+		return nil
+	}
+
+	headers := make(map[string]string)
+	for _, part := range strings.Split(headerStr, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		kv := strings.SplitN(part, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(kv[0])
+		if name == "" {
+			continue
+		}
+		headers[name] = strings.TrimSpace(kv[1])
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
 }
 
 func ParseCookies(cookieStr string) []*http.Cookie {
@@ -122,6 +154,10 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 		}
 		req.Header.Set("Authorization", "Bearer "+c.token)
 		req.Header.Set("Content-Type", "application/json")
+
+		for name, value := range c.headers {
+			req.Header.Set(name, value)
+		}
 
 		for _, cookie := range c.cookies {
 			req.AddCookie(cookie)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Timezone                 string
 	Language                 string
 	RemnawaveCookies         string
+	RemnawaveHeaders         string
 	WebhookURL               string
 	WebhookSecret            string
 	SubnetGrouping           bool
@@ -136,6 +137,7 @@ func LoadConfigWithOverrides(envPath string, overrides map[string]string) (*Conf
 		Timezone:                 l.getEnv("TIMEZONE", "UTC"),
 		Language:                 l.getEnv("LANGUAGE", "ru"),
 		RemnawaveCookies:         l.getEnv("REMNAWAVE_COOKIES", ""),
+		RemnawaveHeaders:         l.getEnv("REMNAWAVE_HEADERS", ""),
 		WebhookURL:               l.getEnv("WEBHOOK_URL", ""),
 		WebhookSecret:            l.getEnv("WEBHOOK_SECRET", ""),
 		SubnetGrouping:           l.getEnvBool("SUBNET_GROUPING", false),


### PR DESCRIPTION
## `REMNAWAVE_HEADERS`

Позволяет задать произвольные HTTP-заголовки, которые будут добавляться к **каждому** запросу к Remnawave API.

**Формат:** пары `Name: Value`, разделённые точкой с запятой (`;`).

```
REMNAWAVE_HEADERS=CF-Access-Client-Id: <id>; CF-Access-Client-Secret: <secret>
```

**По умолчанию:** не задано (заголовки не добавляются).

### Для чего нужно

Если панель Remnawave спрятана за слоем доступа, который требует дополнительных заголовков, без них запрос блокируется ещё до того, как дойдёт до самой панели — и лимитер не может аутентифицироваться.

Типичный случай — **Cloudflare Access / cloudflared-туннель** с сервис-токеном. Доступ к origin разрешён только при наличии заголовков `CF-Access-Client-Id` и `CF-Access-Client-Secret`. Эта переменная как раз и позволяет их прокинуть.

### Разбор значения

- Строка разбивается по `;` на отдельные заголовки.
- Каждый заголовок делится по первому `:` на имя и значение.
- Пробелы вокруг имени и значения обрезаются, так что `CF-Access-Client-Id: <id>` и `CF-Access-Client-Id:<id>` эквивалентны.
- Двоеточия внутри значения сохраняются (делится только по первому `:`).

### Примеры

Один заголовок:

```
REMNAWAVE_HEADERS=X-Custom-Token: abc123
```

Несколько заголовков:

```
REMNAWAVE_HEADERS=CF-Access-Client-Id: a1b2c3.access; CF-Access-Client-Secret: deadbeef...
```